### PR TITLE
fix(prisma): use supported ExperimentTracker APIs in guide

### DIFF
--- a/prisma/src/luml_prisma/data/guide.md
+++ b/prisma/src/luml_prisma/data/guide.md
@@ -190,17 +190,17 @@ After training and saving the model, use `link_to_model()` to embed experiment d
 
 ```python
 from pathlib import Path
-from luml import ExperimentTracker
+from luml.experiments.tracker import ExperimentTracker
 from luml.integrations.sklearn import save_sklearn
 
 tracker = ExperimentTracker(f"sqlite://{Path.home()}/.luml/experiments")
 exp_id = tracker.start_experiment(name="my-experiment")
 # ... training ...
-tracker.log_metrics({"accuracy": 0.92}, step=0)
+tracker.log_dynamic("accuracy", 0.92, step=0)
 
 model_ref = save_sklearn(model, X_train, path=".prisma/artifact.luml")
 tracker.link_to_model(model_ref)
-tracker.set_status("completed")
+tracker.end_experiment()
 ```
 
 The upload is triggered automatically when:
@@ -240,7 +240,7 @@ Each element in the array:
 
 ## ExperimentTracker Convention
 
-**PyPI package:** `luml-sdk` (import as `from luml import ExperimentTracker`)
+**PyPI package:** `luml-sdk` (import as `from luml.experiments.tracker import ExperimentTracker`)
 
 All experiments are stored in a shared global database at:
 
@@ -258,17 +258,19 @@ f"sqlite://{Path.home()}/.luml/experiments"
 
 ```python
 from pathlib import Path
-from luml import ExperimentTracker
+from luml.experiments.tracker import ExperimentTracker
 
 tracker = ExperimentTracker(f"sqlite://{Path.home()}/.luml/experiments")
-exp = tracker.create_experiment(name="my-experiment")
-exp.log_params({"learning_rate": 0.01, "batch_size": 32})
+exp_id = tracker.start_experiment(name="my-experiment")
+tracker.log_static("learning_rate", 0.01)
+tracker.log_static("batch_size", 32)
 
 for step in range(num_steps):
     # ... training ...
-    exp.log_metrics({"loss": loss_val, "accuracy": acc_val}, step=step)
+    tracker.log_dynamic("loss", loss_val, step=step)
+    tracker.log_dynamic("accuracy", acc_val, step=step)
 
-exp.set_status("completed")
+tracker.end_experiment()
 ```
 
 ### Database Structure

--- a/prisma/tests/test_prisma_dir.py
+++ b/prisma/tests/test_prisma_dir.py
@@ -1,9 +1,11 @@
 import importlib.resources
 import os
+import re
 import subprocess
 from pathlib import Path
 
 import pytest
+from luml.experiments.tracker import ExperimentTracker
 
 from luml_prisma.services.orchestrator.utils import (
     ensure_global_luml_dir,
@@ -129,6 +131,23 @@ def test_guide_md_contains_required_sections(tmp_path: Path) -> None:
     assert ".luml/experiments" in content
 
     assert "Metric" in content
+
+
+def test_guide_md_tracker_methods_exist() -> None:
+    source = importlib.resources.files("luml_prisma.data").joinpath("guide.md")
+    content = source.read_text(encoding="utf-8")
+    python_blocks = re.findall(r"^```python\s*\n(.*?)^```\s*$", content, re.M | re.S)
+    methods = {
+        method
+        for block in python_blocks
+        for method in re.findall(r"\b(?:tracker|exp)\.(\w+)\s*\(", block)
+    }
+
+    assert methods, "No ExperimentTracker calls found in guide.md Python blocks"
+    missing = sorted(
+        method for method in methods if not hasattr(ExperimentTracker, method)
+    )
+    assert not missing, f"Unknown ExperimentTracker methods in guide.md: {missing}"
 
 
 @pytest.fixture


### PR DESCRIPTION
Prisma agents copy tracking code from the packaged guide, but both examples call nonexistent `ExperimentTracker` methods and fail at runtime. Update them to use `start_experiment`, `log_static`, `log_dynamic`, and `end_experiment`, retaining model linking in the artifact example.

Also correct the imports to `luml.experiments.tracker`, matching Prisma's existing code: the current SDK does not export `ExperimentTracker` from its top-level package.

Add a regression test that extracts every `tracker.<method>(` and `exp.<method>(` call from the guide's fenced Python blocks and checks each against the SDK class. It also asserts that calls were found to prevent an empty extraction from silently passing.

Validation:
- Confirmed the regression test fails against the original guide, identifying all four nonexistent methods.
- `uv run --frozen pytest tests/test_prisma_dir.py -q`: 15 passed; also passed with `PYTHONPATH=../sdk/python/sdk` to use the repository SDK.
- `uv run --frozen ruff check tests/test_prisma_dir.py` and `git diff --check`: passed.
- Full Prisma suite: 568 passed, 2 failed. Both failures reproduce on unchanged upstream: `test_open_terminal_agent_mode` depends on an unavailable `claude` executable, and `test_list_branches` lacks a Git identity in its temporary repository. The branch test passes when author/committer environment variables are supplied.
