### PR TITLE
fix/LM-194-fix-admin-invite-logic

### DIFF
--- a/backend/luml/handlers/organizations.py
+++ b/backend/luml/handlers/organizations.py
@@ -180,6 +180,14 @@ class OrganizationHandler:
             Resource.ORGANIZATION_INVITE,
             Action.CREATE,
         )
+        user_role = await self.__user_repository.get_organization_member_role(
+            invite_.organization_id, user_id
+        )
+
+        if user_role != OrgRole.OWNER and invite_.role == OrgRole.ADMIN:
+            raise InsufficientPermissionsError(
+                "Only Organization Owner can invite new admins."
+            )
 
         user_info = await self.__user_repository.get_public_user_by_id(user_id)
 

--- a/backend/tests/unit/handlers/test_organization_invites.py
+++ b/backend/tests/unit/handlers/test_organization_invites.py
@@ -4,7 +4,7 @@ from uuid import UUID
 
 import pytest
 from luml.handlers.organizations import OrganizationHandler
-from luml.infra.exceptions import ApplicationError
+from luml.infra.exceptions import ApplicationError, InsufficientPermissionsError
 from luml.models import OrganizationInviteOrm
 from luml.schemas.organization import (
     CreateOrganizationInvite,
@@ -55,6 +55,13 @@ handler = OrganizationHandler()
     "luml.handlers.organizations.InviteRepository.create_organization_invite",
     new_callable=AsyncMock,
 )
+@pytest.mark.parametrize(
+    ("inviter_role", "invite_role"),
+    [
+        (OrgRole.OWNER, OrgRole.ADMIN),
+        (OrgRole.ADMIN, OrgRole.MEMBER),
+    ],
+)
 @pytest.mark.asyncio
 async def test_send_invite(
     mock_create_organization_invite: AsyncMock,
@@ -68,18 +75,20 @@ async def test_send_invite(
     mock_get_organization_invite_by_email: AsyncMock,
     invite_data: CreateOrganizationInvite,
     test_user_out: UserOut,
+    inviter_role: OrgRole,
+    invite_role: OrgRole,
 ) -> None:
     invite_id = UUID("0199c416-6117-7a3d-a91c-9b4037837882")
 
     invite = CreateOrganizationInviteIn(
         email=invite_data.email,
-        role=invite_data.role,
+        role=invite_role,
         organization_id=invite_data.organization_id,
     )
     mocked_invite = OrganizationInvite(
         id=invite_id,
         email=invite_data.email,
-        role=invite_data.role,
+        role=invite_role,
         organization_id=invite_data.organization_id,
         created_at=datetime.now(),
     )
@@ -90,7 +99,7 @@ async def test_send_invite(
     mock_get_public_user_by_id.return_value = test_user_out
     mock_create_organization_invite.return_value = mocked_invite
     mock_get_invite.return_value = mocked_invite
-    mock_get_organization_member_role.return_value = OrgRole.OWNER
+    mock_get_organization_member_role.return_value = inviter_role
     mock_get_organization_details.return_value = Mock(members_limit=50, total_members=0)
 
     result = await handler.send_invite(test_user_out.id, invite)
@@ -99,6 +108,36 @@ async def test_send_invite(
 
     mock_send_organization_invite_email.assert_called_once()
     mock_create_organization_invite.assert_awaited_once()
+
+
+@patch(
+    "luml.handlers.organizations.InviteRepository.create_organization_invite",
+    new_callable=AsyncMock,
+)
+@patch(
+    "luml.handlers.permissions.UserRepository.get_organization_member_role",
+    new_callable=AsyncMock,
+)
+@pytest.mark.asyncio
+async def test_admin_cannot_invite_another_admin(
+    mock_get_organization_member_role: AsyncMock,
+    mock_create_organization_invite: AsyncMock,
+    invite_data: CreateOrganizationInvite,
+) -> None:
+    invite = CreateOrganizationInviteIn(
+        email=invite_data.email,
+        role=OrgRole.ADMIN,
+        organization_id=invite_data.organization_id,
+    )
+    mock_get_organization_member_role.return_value = OrgRole.ADMIN
+
+    with pytest.raises(
+        InsufficientPermissionsError,
+        match="Only Organization Owner can invite new admins.",
+    ):
+        await handler.send_invite(invite_data.invited_by, invite)
+
+    mock_create_organization_invite.assert_not_awaited()
 
 
 @patch(


### PR DESCRIPTION
Restricts organization admin invitations to owners, matching the existing member-role authorization rules. Adds coverage for permitted owner/admin and admin/member invitations and rejects admin/admin invitations.