### PR TITLE
fix/LM-490-hide-empty-attachments

### DIFF
--- a/extras/js/packages/attachments/src/models/TarAttachmentsProvider.ts
+++ b/extras/js/packages/attachments/src/models/TarAttachmentsProvider.ts
@@ -19,6 +19,7 @@ interface ModelDownloader {
 export interface TarAttachmentsProviderConfig {
   downloader: ModelDownloader
   fileIndex: FileIndex
+  attachmentsIndex?: FileIndex
   findAttachmentsTarPath: (fileIndex: FileIndex) => string | undefined
   findAttachmentsIndexPath: (fileIndex: FileIndex) => string | undefined
 }
@@ -28,6 +29,7 @@ export class TarAttachmentsProvider implements ModelAttachmentsProvider {
   private fileIndex: FileIndex
   private findAttachmentsTarPath: (fileIndex: FileIndex) => string | undefined
   private findAttachmentsIndexPath: (fileIndex: FileIndex) => string | undefined
+  private initialAttachmentsIndex?: FileIndex
 
   private tree: FileNode[] = []
   private tarBaseOffset: number = 0
@@ -38,6 +40,7 @@ export class TarAttachmentsProvider implements ModelAttachmentsProvider {
     this.fileIndex = config.fileIndex
     this.findAttachmentsTarPath = config.findAttachmentsTarPath
     this.findAttachmentsIndexPath = config.findAttachmentsIndexPath
+    this.initialAttachmentsIndex = config.attachmentsIndex
   }
 
   async init(): Promise<void> {
@@ -46,7 +49,9 @@ export class TarAttachmentsProvider implements ModelAttachmentsProvider {
       return
     }
 
-    const indexData = await this.downloader.getFileFromBucket<FileIndex>(this.fileIndex, indexPath)
+    const indexData =
+      this.initialAttachmentsIndex ??
+      (await this.downloader.getFileFromBucket<FileIndex>(this.fileIndex, indexPath))
 
     const tarPath = this.findAttachmentsTarPath(this.fileIndex)
     if (!tarPath) {

--- a/frontend/src/components/orbits/tabs/registry/collection/artifact/ArtifactTabs.vue
+++ b/frontend/src/components/orbits/tabs/registry/collection/artifact/ArtifactTabs.vue
@@ -40,7 +40,6 @@ type Props = {
 
   cardDisabled: boolean
   experimentSnapshotDisabled: boolean
-  modelAttachmentsDisabled: boolean
 }
 
 const tabsListPT = {
@@ -83,7 +82,6 @@ const items = computed(() => [
     routeName: 'attachments',
     icon: Paperclip,
     visible: props.showModelAttachments,
-    disabled: props.modelAttachmentsDisabled,
   },
   {
     label: 'Lineage',

--- a/frontend/src/components/orbits/tabs/registry/collection/artifact/__tests__/ArtifactTabs.test.ts
+++ b/frontend/src/components/orbits/tabs/registry/collection/artifact/__tests__/ArtifactTabs.test.ts
@@ -1,0 +1,49 @@
+import { mount } from '@vue/test-utils'
+import { defineComponent } from 'vue'
+import { describe, expect, it, vi } from 'vitest'
+import ArtifactTabs from '../ArtifactTabs.vue'
+
+const SlotStub = defineComponent({ template: '<div><slot /></div>' })
+const TabStub = defineComponent({
+  props: ['disabled', 'value'],
+  template: '<div class="tab-stub"><slot /></div>',
+})
+const RouterLinkStub = defineComponent({
+  props: ['to'],
+  template: '<a><slot /></a>',
+})
+
+function mountTabs(showModelAttachments: boolean) {
+  return mount(ArtifactTabs, {
+    props: {
+      showDataTab: false,
+      showCard: true,
+      showExperimentSnapshot: true,
+      showModelAttachments,
+      cardDisabled: false,
+      experimentSnapshotDisabled: false,
+    },
+    global: {
+      mocks: {
+        $route: { name: 'artifact' },
+        $router: { push: vi.fn() },
+      },
+      stubs: {
+        Tabs: SlotStub,
+        TabList: SlotStub,
+        Tab: TabStub,
+        RouterLink: RouterLinkStub,
+      },
+    },
+  })
+}
+
+describe('ArtifactTabs', () => {
+  it('hides the attachments tab when the artifact has no attachments', () => {
+    expect(mountTabs(false).text()).not.toContain('Attachments')
+  })
+
+  it('shows the attachments tab when the artifact has attachments', () => {
+    expect(mountTabs(true).text()).toContain('Attachments')
+  })
+})

--- a/frontend/src/lib/fnnx/FnnxService.ts
+++ b/frontend/src/lib/fnnx/FnnxService.ts
@@ -207,7 +207,10 @@ class FnnxServiceClass {
   }
 
   hasAttachments(fileIndex: FileIndex) {
-    return !!this.findAttachmentsTarPath(fileIndex)
+    const archivePath = this.findAttachmentsTarPath(fileIndex)
+    const indexPath = this.findAttachmentsIndexPath(fileIndex)
+    if (!archivePath || !indexPath) return false
+    return fileIndex[indexPath][1] > '{}'.length
   }
 
   findAttachmentsTarPath(fileIndex: FileIndex) {

--- a/frontend/src/lib/fnnx/FnnxService.ts
+++ b/frontend/src/lib/fnnx/FnnxService.ts
@@ -212,6 +212,24 @@ class FnnxServiceClass {
     )
   }
 
+  isValidAttachmentsIndex(value: unknown, archiveSize: number): value is FileIndex {
+    if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+    if (!Number.isSafeInteger(archiveSize) || archiveSize < 0) return false
+
+    return Object.entries(value).every(([path, range]) => {
+      if (!path || !Array.isArray(range) || range.length !== 2) return false
+      const [offset, size] = range
+      return (
+        Number.isSafeInteger(offset) &&
+        Number.isSafeInteger(size) &&
+        offset >= 0 &&
+        size >= 0 &&
+        Number.isSafeInteger(offset + size) &&
+        offset + size <= archiveSize
+      )
+    })
+  }
+
   findAttachmentsTarPath(fileIndex: FileIndex) {
     const regex =
       /meta_artifacts\/dataforce\.studio~c~~c~experiment_snapshot~c~v1~~et~~[^/]+\/attachments\.tar$|^attachments\.tar$/

--- a/frontend/src/lib/fnnx/FnnxService.ts
+++ b/frontend/src/lib/fnnx/FnnxService.ts
@@ -206,11 +206,10 @@ class FnnxServiceClass {
     return Object.keys(fileIndex).find((file) => regex.test(file))
   }
 
-  hasAttachments(fileIndex: FileIndex) {
-    const archivePath = this.findAttachmentsTarPath(fileIndex)
-    const indexPath = this.findAttachmentsIndexPath(fileIndex)
-    if (!archivePath || !indexPath) return false
-    return fileIndex[indexPath][1] > '{}'.length
+  hasAttachments(attachmentsIndex: FileIndex) {
+    return Object.entries(attachmentsIndex).some(
+      ([path, [, size]]) => size > 0 && !path.endsWith('/'),
+    )
   }
 
   findAttachmentsTarPath(fileIndex: FileIndex) {

--- a/frontend/src/lib/fnnx/__tests__/FnnxService.test.ts
+++ b/frontend/src/lib/fnnx/__tests__/FnnxService.test.ts
@@ -77,3 +77,29 @@ describe('FnnxService.hasAttachments', () => {
     expect(FnnxService.hasAttachments(fileIndex)).toBe(true)
   })
 })
+
+describe('FnnxService.isValidAttachmentsIndex', () => {
+  it('accepts file ranges contained by the attachment archive', () => {
+    expect(
+      FnnxService.isValidAttachmentsIndex(
+        {
+          'attachments/': [0, 0],
+          'attachments/report.pdf': [512, 42],
+        },
+        1024,
+      ),
+    ).toBe(true)
+  })
+
+  it.each([
+    null,
+    [],
+    { 'attachments/report.pdf': null },
+    { 'attachments/report.pdf': [-1, 42] },
+    { 'attachments/report.pdf': [0, -1] },
+    { 'attachments/report.pdf': [900, 200] },
+    { 'attachments/report.pdf': ['0', 42] },
+  ])('rejects malformed or out-of-bounds index content', (value) => {
+    expect(FnnxService.isValidAttachmentsIndex(value, 1024)).toBe(false)
+  })
+})

--- a/frontend/src/lib/fnnx/__tests__/FnnxService.test.ts
+++ b/frontend/src/lib/fnnx/__tests__/FnnxService.test.ts
@@ -45,3 +45,33 @@ describe('FnnxService.findHtmlCard', () => {
     expect(FnnxService.findHtmlCard(fileIndex)).toBe('card.zip')
   })
 })
+
+describe('FnnxService.hasAttachments', () => {
+  const archivePath =
+    'meta_artifacts/dataforce.studio~c~~c~experiment_snapshot~c~v1~~et~~abc123/attachments.tar'
+  const indexPath =
+    'meta_artifacts/dataforce.studio~c~~c~experiment_snapshot~c~v1~~et~~abc123/attachments.index.json'
+
+  it('returns true when the attachments index contains files', () => {
+    const fileIndex: FileIndex = {
+      [archivePath]: [0, 10240],
+      [indexPath]: [10240, 42],
+    }
+
+    expect(FnnxService.hasAttachments(fileIndex)).toBe(true)
+  })
+
+  it('returns false when the attachments index is empty', () => {
+    const fileIndex: FileIndex = {
+      [archivePath]: [0, 10240],
+      [indexPath]: [10240, 2],
+    }
+
+    expect(FnnxService.hasAttachments(fileIndex)).toBe(false)
+  })
+
+  it('returns false when the archive or index is missing', () => {
+    expect(FnnxService.hasAttachments({ [archivePath]: [0, 10240] })).toBe(false)
+    expect(FnnxService.hasAttachments({ [indexPath]: [0, 42] })).toBe(false)
+  })
+})

--- a/frontend/src/lib/fnnx/__tests__/FnnxService.test.ts
+++ b/frontend/src/lib/fnnx/__tests__/FnnxService.test.ts
@@ -47,31 +47,33 @@ describe('FnnxService.findHtmlCard', () => {
 })
 
 describe('FnnxService.hasAttachments', () => {
-  const archivePath =
-    'meta_artifacts/dataforce.studio~c~~c~experiment_snapshot~c~v1~~et~~abc123/attachments.tar'
-  const indexPath =
-    'meta_artifacts/dataforce.studio~c~~c~experiment_snapshot~c~v1~~et~~abc123/attachments.index.json'
-
   it('returns true when the attachments index contains files', () => {
     const fileIndex: FileIndex = {
-      [archivePath]: [0, 10240],
-      [indexPath]: [10240, 42],
+      'attachments/report.pdf': [0, 42],
     }
 
     expect(FnnxService.hasAttachments(fileIndex)).toBe(true)
   })
 
   it('returns false when the attachments index is empty', () => {
-    const fileIndex: FileIndex = {
-      [archivePath]: [0, 10240],
-      [indexPath]: [10240, 2],
-    }
-
-    expect(FnnxService.hasAttachments(fileIndex)).toBe(false)
+    expect(FnnxService.hasAttachments({})).toBe(false)
   })
 
-  it('returns false when the archive or index is missing', () => {
-    expect(FnnxService.hasAttachments({ [archivePath]: [0, 10240] })).toBe(false)
-    expect(FnnxService.hasAttachments({ [indexPath]: [0, 42] })).toBe(false)
+  it('ignores directory entries', () => {
+    expect(FnnxService.hasAttachments({ 'attachments/': [0, 512] })).toBe(false)
+  })
+
+  it('ignores zero-byte files', () => {
+    expect(FnnxService.hasAttachments({ 'attachments/empty.txt': [0, 0] })).toBe(false)
+  })
+
+  it('returns true when usable files appear beside ignored entries', () => {
+    const fileIndex: FileIndex = {
+      'attachments/': [0, 512],
+      'attachments/empty.txt': [512, 0],
+      'attachments/report.pdf': [512, 42],
+    }
+
+    expect(FnnxService.hasAttachments(fileIndex)).toBe(true)
   })
 })

--- a/frontend/src/pages/collection/artifact/AttachmentsView.vue
+++ b/frontend/src/pages/collection/artifact/AttachmentsView.vue
@@ -1,50 +1,67 @@
 <template>
-  <UiPageLoader v-if="loading" />
+  <UiPageLoader v-if="artifactsStore.attachmentsStatus === 'loading' || loading" />
+  <div v-else-if="artifactsStore.attachmentsStatus === 'error' || error" class="attachments-error">
+    <p>{{ error ?? artifactsStore.attachmentsError }}</p>
+    <Button label="Try again" severity="secondary" @click="retry" />
+  </div>
   <ModelAttachments v-else-if="provider" :provider="provider" class="attachments" />
 </template>
 
 <script setup lang="ts">
 import { ModelAttachments } from '@luml/attachments'
-import { onMounted } from 'vue'
 import { useArtifactsStore } from '@/stores/artifacts'
-import { useTarAttachmentsProvider } from '@/hooks/useTarAttachmentsProvider'
-import { ModelDownloader } from '@/lib/bucket-service'
-import { FnnxService } from '@/lib/fnnx/FnnxService'
-import { getErrorMessage } from '@/helpers/helpers'
-import { useToast } from 'primevue'
-import { simpleErrorToast } from '@/lib/primevue/data/toasts'
+import { Button } from 'primevue'
 import UiPageLoader from '@/components/ui/UiPageLoader.vue'
+import { useTarAttachmentsProvider } from '@/hooks/useTarAttachmentsProvider'
+import { FnnxService } from '@/lib/fnnx/FnnxService'
+import { watch } from 'vue'
 
 const artifactsStore = useArtifactsStore()
-const { provider, loading, init } = useTarAttachmentsProvider()
-const toast = useToast()
+const { provider, loading, error, init } = useTarAttachmentsProvider()
 
-onMounted(async () => {
-  if (provider.value) return
+async function initializeProvider() {
+  const artifact = artifactsStore.currentArtifact
+  const downloader = artifactsStore.attachmentsDownloader
+  const attachmentsIndex = artifactsStore.attachmentsIndex
+  if (!artifact || !downloader || !attachmentsIndex || provider.value) return
 
   try {
-    if (!artifactsStore.currentArtifact?.file_index) {
-      throw new Error('Artifact or file index does not exist')
-    }
-
-    const url = await artifactsStore.getDownloadUrl(artifactsStore.currentArtifact.id)
-    const downloader = new ModelDownloader(url)
-
     await init({
       downloader,
-      fileIndex: artifactsStore.currentArtifact.file_index,
+      fileIndex: artifact.file_index,
+      attachmentsIndex,
       findAttachmentsTarPath: FnnxService.findAttachmentsTarPath,
       findAttachmentsIndexPath: FnnxService.findAttachmentsIndexPath,
     })
-  } catch (e) {
-    const message = getErrorMessage(e, 'Failed to initialize attachments')
-    toast.add(simpleErrorToast(message))
+  } catch {
+    // the provider exposes the initialization error for an in-page retry
   }
-})
+}
+
+watch(
+  () => artifactsStore.attachmentsStatus,
+  (status) => {
+    if (status === 'available') void initializeProvider()
+  },
+  { immediate: true },
+)
+
+async function retry() {
+  if (artifactsStore.currentArtifact) {
+    await artifactsStore.loadCurrentArtifactAttachments(artifactsStore.currentArtifact)
+  }
+}
 </script>
 
 <style scoped>
 .attachments {
   height: calc(100vh - 320px);
+}
+
+.attachments-error {
+  display: flex;
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 12px;
 }
 </style>

--- a/frontend/src/pages/collection/artifact/__tests__/ArtifactPage.test.ts
+++ b/frontend/src/pages/collection/artifact/__tests__/ArtifactPage.test.ts
@@ -1,0 +1,199 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { flushPromises, shallowMount } from '@vue/test-utils'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from 'axios'
+import { ArtifactStatusEnum, ArtifactTypeEnum, type Artifact } from '@/lib/api/artifacts/interfaces'
+import ArtifactPage from '../index.vue'
+
+const apiMocks = vi.hoisted(() => ({
+  getArtifact: vi.fn(),
+  getDownloadUrl: vi.fn(),
+}))
+
+const routerHarness = vi.hoisted(() => ({
+  route: null as null | {
+    name: string
+    params: Record<string, string>
+  },
+  replace: vi.fn(),
+  push: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    artifacts: {
+      getById: apiMocks.getArtifact,
+      getDownloadUrl: apiMocks.getDownloadUrl,
+    },
+  },
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+vi.mock('vue-router', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('vue-router')>()
+  const { reactive } = await import('vue')
+  routerHarness.route = reactive({
+    name: 'artifact',
+    params: {
+      organizationId: 'org',
+      id: 'orbit',
+      collectionId: 'collection',
+      artifactId: 'model',
+    },
+  })
+  return {
+    ...actual,
+    useRoute: () => routerHarness.route,
+    useRouter: () => ({ push: routerHarness.push, replace: routerHarness.replace }),
+  }
+})
+
+vi.mock('primevue', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('primevue')>()
+  return { ...actual, useToast: () => ({ add: vi.fn() }) }
+})
+
+vi.mock('@/stores/orbits', () => ({
+  useOrbitsStore: () => ({ getCurrentOrbitPermissions: null }),
+}))
+
+vi.mock('@/stores/collections', () => ({
+  useCollectionsStore: () => ({ currentCollection: null }),
+}))
+
+vi.mock('@/stores/datasets', () => ({
+  useDatasetsStore: () => ({ reset: vi.fn() }),
+}))
+
+vi.mock('@/components/orbits/tabs/registry/collection/artifact/ArtifactTabs.vue', async () => {
+  const { defineComponent } = await import('vue')
+  return {
+    default: defineComponent({
+      name: 'ArtifactTabs',
+      props: {
+        showModelAttachments: Boolean,
+        showDataTab: Boolean,
+        showCard: Boolean,
+        showExperimentSnapshot: Boolean,
+        cardDisabled: Boolean,
+        experimentSnapshotDisabled: Boolean,
+      },
+      template: '<div />',
+    }),
+  }
+})
+
+vi.mock('@/components/deployments/create/DeploymentsCreateModal.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock('@/components/orbits/tabs/registry/collection/artifact/ArtifactEditor.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock('@/components/tracks/LinkArtifactToTrack.vue', () => ({
+  default: { template: '<div />' },
+}))
+
+vi.mock(
+  '@/components/orbits/tabs/registry/collection/artifacts-table/ArtifactsDeploymentsModal.vue',
+  () => ({ default: { template: '<div />' } }),
+)
+
+const mockedAxios = vi.mocked(axios)
+
+function model(): Artifact {
+  return {
+    id: 'model',
+    type: ArtifactTypeEnum.model,
+    status: ArtifactStatusEnum.uploaded,
+    size: 200,
+    file_index: {
+      'attachments.tar': [0, 100],
+      'attachments.index.json': [100, 50],
+    },
+    manifest: { producer_tags: [], dynamic_attributes: [], env_vars: [] },
+  } as unknown as Artifact
+}
+
+function mountPage() {
+  const pinia = createPinia()
+  setActivePinia(pinia)
+  return shallowMount(ArtifactPage, {
+    global: {
+      plugins: [pinia],
+      stubs: {
+        RouterView: true,
+        DeploymentsCreateModal: true,
+        ArtifactEditor: true,
+        LinkArtifactToTrack: true,
+        ArtifactsDeploymentsModal: true,
+      },
+      directives: { tooltip: () => {} },
+    },
+  })
+}
+
+describe('artifact page attachment tab', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    apiMocks.getArtifact.mockReset()
+    apiMocks.getDownloadUrl.mockReset()
+    mockedAxios.get.mockReset()
+    routerHarness.replace.mockReset()
+    routerHarness.push.mockReset()
+    if (!routerHarness.route) throw new Error('Route harness was not initialized')
+    routerHarness.route.name = 'artifact'
+    routerHarness.route.params.artifactId = 'model'
+    apiMocks.getArtifact.mockResolvedValue(model())
+    apiMocks.getDownloadUrl.mockResolvedValue({ url: 'https://download.test/model' })
+  })
+
+  it('shows the tab after reading a non-empty attachment index', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { 'attachments/report.pdf': [0, 42] },
+    })
+    const wrapper = mountPage()
+
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'ArtifactTabs' }).props('showModelAttachments')).toBe(true)
+  })
+
+  it('hides the tab after reading an empty attachment index', async () => {
+    mockedAxios.get.mockResolvedValue({ data: {} })
+    const wrapper = mountPage()
+
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'ArtifactTabs' }).props('showModelAttachments')).toBe(
+      false,
+    )
+  })
+
+  it('keeps the tab available when index inspection fails', async () => {
+    apiMocks.getDownloadUrl.mockRejectedValue(new Error('temporary failure'))
+    const wrapper = mountPage()
+
+    await flushPromises()
+
+    expect(wrapper.findComponent({ name: 'ArtifactTabs' }).props('showModelAttachments')).toBe(true)
+  })
+
+  it('redirects a direct empty-attachments route to the overview', async () => {
+    if (!routerHarness.route) throw new Error('Route harness was not initialized')
+    routerHarness.route.name = 'attachments'
+    mockedAxios.get.mockResolvedValue({ data: {} })
+    mountPage()
+
+    await flushPromises()
+
+    expect(routerHarness.replace).toHaveBeenCalledWith({ name: 'artifact' })
+  })
+})

--- a/frontend/src/pages/collection/artifact/index.vue
+++ b/frontend/src/pages/collection/artifact/index.vue
@@ -42,11 +42,10 @@
     <ArtifactTabs
       :card-disabled="!isCardAvailable"
       :experiment-snapshot-disabled="!isExperimentSnapshotCardAvailable"
-      :model-attachments-disabled="!isModelAttachmentsAvailable"
       :show-data-tab="isDataTabVisible"
       :show-card="true"
       :show-experiment-snapshot="isExperimentSnapshotVisible"
-      :show-model-attachments="isModelAttachmentsVisible"
+      :show-model-attachments="isModelAttachmentsAvailable"
     ></ArtifactTabs>
     <div class="view-wrapper">
       <RouterView></RouterView>
@@ -120,14 +119,6 @@ const isExperimentSnapshotVisible = computed(() => {
   )
 })
 
-const isModelAttachmentsVisible = computed(() => {
-  if (!artifactsStore.currentArtifact) return false
-  return (
-    artifactsStore.currentArtifact.type === ArtifactTypeEnum.model ||
-    artifactsStore.currentArtifact.type === ArtifactTypeEnum.experiment
-  )
-})
-
 const isCardAvailable = computed(() => {
   if (!artifactsStore.currentArtifact) return false
   const fileIndex = artifactsStore.currentArtifact.file_index
@@ -142,8 +133,14 @@ const isExperimentSnapshotCardAvailable = computed(() => {
 })
 
 const isModelAttachmentsAvailable = computed(() => {
-  if (!artifactsStore.currentArtifact) return false
-  const fileIndex = artifactsStore.currentArtifact.file_index
+  const artifact = artifactsStore.currentArtifact
+  if (
+    !artifact ||
+    (artifact.type !== ArtifactTypeEnum.model && artifact.type !== ArtifactTypeEnum.experiment)
+  ) {
+    return false
+  }
+  const fileIndex = artifact.file_index
   if (!fileIndex) return false
   return FnnxService.hasAttachments(fileIndex)
 })

--- a/frontend/src/pages/collection/artifact/index.vue
+++ b/frontend/src/pages/collection/artifact/index.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-import { ArtifactTypeEnum, type Artifact, type FileIndex } from '@/lib/api/artifacts/interfaces'
+import { ArtifactTypeEnum, type Artifact } from '@/lib/api/artifacts/interfaces'
 import { useArtifactsStore } from '@/stores/artifacts'
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -90,7 +90,6 @@ import DeploymentsCreateModal from '@/components/deployments/create/DeploymentsC
 import ArtifactEditor from '@/components/orbits/tabs/registry/collection/artifact/ArtifactEditor.vue'
 import LinkArtifactToTrack from '@/components/tracks/LinkArtifactToTrack.vue'
 import ArtifactsDeploymentsModal from '@/components/orbits/tabs/registry/collection/artifacts-table/ArtifactsDeploymentsModal.vue'
-import { ModelDownloader } from '@/lib/bucket-service'
 
 const artifactsStore = useArtifactsStore()
 const route = useRoute()
@@ -102,7 +101,6 @@ const datasetsStore = useDatasetsStore()
 
 const modelForDeployment = ref<string | null>(null)
 const modelForEdit = ref<Artifact | null>(null)
-const isModelAttachmentsAvailable = ref(false)
 
 const isDeployButtonVisible = computed(() => {
   return artifactsStore.currentArtifact?.type === ArtifactTypeEnum.model
@@ -134,32 +132,17 @@ const isExperimentSnapshotCardAvailable = computed(() => {
   return !!FnnxService.findExperimentSnapshotArchiveName(fileIndex)
 })
 
-async function updateModelAttachmentsAvailability(artifact: Artifact) {
-  isModelAttachmentsAvailable.value = false
+const isModelAttachmentsAvailable = computed(() => {
+  const artifact = artifactsStore.currentArtifact
+  if (!artifact) return false
   if (artifact.type !== ArtifactTypeEnum.model && artifact.type !== ArtifactTypeEnum.experiment) {
-    return
+    return false
   }
-
   const fileIndex = artifact.file_index
   const archivePath = FnnxService.findAttachmentsTarPath(fileIndex)
   const indexPath = FnnxService.findAttachmentsIndexPath(fileIndex)
-  if (!archivePath || !indexPath) return
-
-  try {
-    const url = await artifactsStore.getDownloadUrl(artifact.id)
-    const downloader = new ModelDownloader(url)
-    const attachmentsIndex = await downloader.getFileFromBucket<FileIndex>(fileIndex, indexPath)
-
-    if (artifactsStore.currentArtifact?.id === artifact.id) {
-      isModelAttachmentsAvailable.value = FnnxService.hasAttachments(attachmentsIndex)
-    }
-  } catch (e) {
-    if (artifactsStore.currentArtifact?.id === artifact.id) {
-      const message = getErrorMessage(e, 'Failed to check attachments')
-      toast.add(simpleErrorToast(message))
-    }
-  }
-}
+  return !!archivePath && !!indexPath && artifactsStore.attachmentsStatus !== 'empty'
+})
 
 function initDeploy() {
   if (artifactsStore.currentArtifact) {
@@ -226,7 +209,14 @@ async function onArtifactIdChange(artifactId: string | string[] | null) {
     }
     const artifact = await artifactsStore.getArtifact(artifactId, requestInfo)
     artifactsStore.setCurrentArtifact(artifact)
-    await updateModelAttachmentsAvailability(artifact)
+    await artifactsStore.loadCurrentArtifactAttachments(artifact)
+    if (
+      artifactsStore.currentArtifact?.id === artifact.id &&
+      artifactsStore.attachmentsStatus === 'empty' &&
+      route.name === 'attachments'
+    ) {
+      await router.replace({ name: 'artifact' })
+    }
   } catch (e) {
     const message = getErrorMessage(e, 'Failed to set current artifact')
     toast.add(simpleErrorToast(message))

--- a/frontend/src/pages/collection/artifact/index.vue
+++ b/frontend/src/pages/collection/artifact/index.vue
@@ -72,7 +72,7 @@
 </template>
 
 <script setup lang="ts">
-import { ArtifactTypeEnum, type Artifact } from '@/lib/api/artifacts/interfaces'
+import { ArtifactTypeEnum, type Artifact, type FileIndex } from '@/lib/api/artifacts/interfaces'
 import { useArtifactsStore } from '@/stores/artifacts'
 import { computed, onUnmounted, ref, watch } from 'vue'
 import { useRoute, useRouter } from 'vue-router'
@@ -90,6 +90,7 @@ import DeploymentsCreateModal from '@/components/deployments/create/DeploymentsC
 import ArtifactEditor from '@/components/orbits/tabs/registry/collection/artifact/ArtifactEditor.vue'
 import LinkArtifactToTrack from '@/components/tracks/LinkArtifactToTrack.vue'
 import ArtifactsDeploymentsModal from '@/components/orbits/tabs/registry/collection/artifacts-table/ArtifactsDeploymentsModal.vue'
+import { ModelDownloader } from '@/lib/bucket-service'
 
 const artifactsStore = useArtifactsStore()
 const route = useRoute()
@@ -101,6 +102,7 @@ const datasetsStore = useDatasetsStore()
 
 const modelForDeployment = ref<string | null>(null)
 const modelForEdit = ref<Artifact | null>(null)
+const isModelAttachmentsAvailable = ref(false)
 
 const isDeployButtonVisible = computed(() => {
   return artifactsStore.currentArtifact?.type === ArtifactTypeEnum.model
@@ -132,18 +134,32 @@ const isExperimentSnapshotCardAvailable = computed(() => {
   return !!FnnxService.findExperimentSnapshotArchiveName(fileIndex)
 })
 
-const isModelAttachmentsAvailable = computed(() => {
-  const artifact = artifactsStore.currentArtifact
-  if (
-    !artifact ||
-    (artifact.type !== ArtifactTypeEnum.model && artifact.type !== ArtifactTypeEnum.experiment)
-  ) {
-    return false
+async function updateModelAttachmentsAvailability(artifact: Artifact) {
+  isModelAttachmentsAvailable.value = false
+  if (artifact.type !== ArtifactTypeEnum.model && artifact.type !== ArtifactTypeEnum.experiment) {
+    return
   }
+
   const fileIndex = artifact.file_index
-  if (!fileIndex) return false
-  return FnnxService.hasAttachments(fileIndex)
-})
+  const archivePath = FnnxService.findAttachmentsTarPath(fileIndex)
+  const indexPath = FnnxService.findAttachmentsIndexPath(fileIndex)
+  if (!archivePath || !indexPath) return
+
+  try {
+    const url = await artifactsStore.getDownloadUrl(artifact.id)
+    const downloader = new ModelDownloader(url)
+    const attachmentsIndex = await downloader.getFileFromBucket<FileIndex>(fileIndex, indexPath)
+
+    if (artifactsStore.currentArtifact?.id === artifact.id) {
+      isModelAttachmentsAvailable.value = FnnxService.hasAttachments(attachmentsIndex)
+    }
+  } catch (e) {
+    if (artifactsStore.currentArtifact?.id === artifact.id) {
+      const message = getErrorMessage(e, 'Failed to check attachments')
+      toast.add(simpleErrorToast(message))
+    }
+  }
+}
 
 function initDeploy() {
   if (artifactsStore.currentArtifact) {
@@ -210,6 +226,7 @@ async function onArtifactIdChange(artifactId: string | string[] | null) {
     }
     const artifact = await artifactsStore.getArtifact(artifactId, requestInfo)
     artifactsStore.setCurrentArtifact(artifact)
+    await updateModelAttachmentsAvailability(artifact)
   } catch (e) {
     const message = getErrorMessage(e, 'Failed to set current artifact')
     toast.add(simpleErrorToast(message))

--- a/frontend/src/stores/__tests__/artifacts-attachments.test.ts
+++ b/frontend/src/stores/__tests__/artifacts-attachments.test.ts
@@ -1,0 +1,185 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import axios from 'axios'
+import { ArtifactStatusEnum, ArtifactTypeEnum, type Artifact } from '@/lib/api/artifacts/interfaces'
+
+const apiMocks = vi.hoisted(() => ({
+  getDownloadUrl: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({
+  api: {
+    artifacts: {
+      getDownloadUrl: apiMocks.getDownloadUrl,
+    },
+  },
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => ({
+    params: { organizationId: 'org', id: 'orbit', collectionId: 'collection' },
+  }),
+}))
+
+vi.mock('axios', () => ({
+  default: {
+    get: vi.fn(),
+    delete: vi.fn(),
+  },
+}))
+
+import { useArtifactsStore } from '@/stores/artifacts'
+
+const mockedAxios = vi.mocked(axios)
+
+function artifact(id = 'model'): Artifact {
+  return {
+    id,
+    type: ArtifactTypeEnum.model,
+    status: ArtifactStatusEnum.uploaded,
+    size: 200,
+    file_index: {
+      'attachments.tar': [0, 100],
+      'attachments.index.json': [100, 50],
+    },
+  } as Artifact
+}
+
+function deferred<T>() {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+describe('artifact attachment loading', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    apiMocks.getDownloadUrl.mockReset()
+    mockedAxios.get.mockReset()
+    apiMocks.getDownloadUrl.mockResolvedValue({ url: 'https://download.test/model' })
+  })
+
+  it('caches the downloaded index and downloader for the attachments view', async () => {
+    mockedAxios.get.mockResolvedValue({
+      data: { 'attachments/report.pdf': [0, 42] },
+    })
+    const store = useArtifactsStore()
+    const model = artifact()
+    store.setCurrentArtifact(model)
+
+    await store.loadCurrentArtifactAttachments(model)
+
+    expect(store.attachmentsStatus).toBe('available')
+    expect(store.attachmentsIndex).toEqual({ 'attachments/report.pdf': [0, 42] })
+    expect(store.attachmentsDownloader).not.toBeNull()
+    expect(mockedAxios.get).toHaveBeenCalledTimes(1)
+  })
+
+  it('marks an empty parsed index as empty', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { 'attachments/': [0, 0] } })
+    const store = useArtifactsStore()
+    const model = artifact()
+    store.setCurrentArtifact(model)
+
+    await store.loadCurrentArtifactAttachments(model)
+
+    expect(store.attachmentsStatus).toBe('empty')
+    expect(store.attachmentsIndex).toBeNull()
+  })
+
+  it('keeps an error state when the download URL request fails', async () => {
+    apiMocks.getDownloadUrl.mockRejectedValue(new Error('url unavailable'))
+    const store = useArtifactsStore()
+    const model = artifact()
+    store.setCurrentArtifact(model)
+
+    await store.loadCurrentArtifactAttachments(model)
+
+    expect(store.attachmentsStatus).toBe('error')
+    expect(store.attachmentsError).toContain('url unavailable')
+    expect(mockedAxios.get).not.toHaveBeenCalled()
+  })
+
+  it('keeps an error state when the attachment index request fails', async () => {
+    mockedAxios.get.mockRejectedValue(new Error('range unavailable'))
+    const store = useArtifactsStore()
+    const model = artifact()
+    store.setCurrentArtifact(model)
+
+    await store.loadCurrentArtifactAttachments(model)
+
+    expect(store.attachmentsStatus).toBe('error')
+    expect(store.attachmentsError).toContain('range unavailable')
+  })
+
+  it('rejects malformed attachment index content', async () => {
+    mockedAxios.get.mockResolvedValue({ data: { 'attachments/report.pdf': [90, 42] } })
+    const store = useArtifactsStore()
+    const model = artifact()
+    store.setCurrentArtifact(model)
+
+    await store.loadCurrentArtifactAttachments(model)
+
+    expect(store.attachmentsStatus).toBe('error')
+    expect(store.attachmentsError).toContain('invalid content')
+  })
+
+  it('rejects an oversized attachment index before requesting it', async () => {
+    const store = useArtifactsStore()
+    const model = artifact()
+    model.size = 2_000_000
+    model.file_index['attachments.index.json'] = [100, 1_048_577]
+    store.setCurrentArtifact(model)
+
+    await store.loadCurrentArtifactAttachments(model)
+
+    expect(store.attachmentsStatus).toBe('error')
+    expect(store.attachmentsError).toContain('invalid range')
+    expect(apiMocks.getDownloadUrl).not.toHaveBeenCalled()
+  })
+
+  it('ignores stale results after navigating to another artifact', async () => {
+    const firstUrl = deferred<{ url: string }>()
+    apiMocks.getDownloadUrl.mockImplementation((...args: unknown[]) => {
+      return args.at(-1) === 'first'
+        ? firstUrl.promise
+        : Promise.resolve({ url: 'https://download.test/second' })
+    })
+    mockedAxios.get.mockImplementation((url) => {
+      return Promise.resolve({
+        data: url === 'https://download.test/first' ? { 'attachments/report.pdf': [0, 42] } : {},
+      })
+    })
+    const store = useArtifactsStore()
+    const first = artifact('first')
+    const second = artifact('second')
+    store.setCurrentArtifact(first)
+    const firstLoad = store.loadCurrentArtifactAttachments(first)
+
+    store.setCurrentArtifact(second)
+    await store.loadCurrentArtifactAttachments(second)
+    firstUrl.resolve({ url: 'https://download.test/first' })
+    await firstLoad
+
+    expect(store.currentArtifact?.id).toBe('second')
+    expect(store.attachmentsStatus).toBe('empty')
+    expect(store.attachmentsIndex).toBeNull()
+  })
+
+  it('can retry after an inspection failure', async () => {
+    apiMocks.getDownloadUrl.mockRejectedValueOnce(new Error('temporary failure'))
+    mockedAxios.get.mockResolvedValue({
+      data: { 'attachments/report.pdf': [0, 42] },
+    })
+    const store = useArtifactsStore()
+    const model = artifact()
+    store.setCurrentArtifact(model)
+    await store.loadCurrentArtifactAttachments(model)
+    await store.loadCurrentArtifactAttachments(model)
+
+    expect(store.attachmentsStatus).toBe('available')
+    expect(apiMocks.getDownloadUrl).toHaveBeenCalledTimes(2)
+  })
+})

--- a/frontend/src/stores/artifacts/index.ts
+++ b/frontend/src/stores/artifacts/index.ts
@@ -1,22 +1,35 @@
-import type { FNNX_PRODUCER_TAGS_MANIFEST_ENUM } from '@/lib/fnnx/FnnxService'
+import { FnnxService, type FNNX_PRODUCER_TAGS_MANIFEST_ENUM } from '@/lib/fnnx/FnnxService'
 import type { ExperimentSnapshotProvider } from '@luml/experiments'
 import type {
   Artifact,
   CreateArtifactPayload,
+  FileIndex,
   UpdateArtifactPayload,
 } from '@/lib/api/artifacts/interfaces'
+import { ArtifactTypeEnum } from '@/lib/api/artifacts/interfaces'
 import type { ModelMetadata, RequestInfo } from './artifacts.interface'
 import { defineStore } from 'pinia'
 import { computed, ref } from 'vue'
 import { api } from '@/lib/api'
 import { useRoute } from 'vue-router'
-import { downloadFileFromBlob } from '@/helpers/helpers'
+import { downloadFileFromBlob, getErrorMessage } from '@/helpers/helpers'
 import axios from 'axios'
+import { ModelDownloader } from '@/lib/bucket-service'
+
+export type ArtifactAttachmentsStatus = 'idle' | 'loading' | 'available' | 'empty' | 'error'
+
+const MAX_ATTACHMENTS_INDEX_SIZE = 1024 * 1024
 
 export const useArtifactsStore = defineStore('artifacts', () => {
   const route = useRoute()
 
   const currentArtifact = ref<Artifact | null>(null)
+
+  const attachmentsIndex = ref<FileIndex | null>(null)
+  const attachmentsDownloader = ref<ModelDownloader | null>(null)
+  const attachmentsStatus = ref<ArtifactAttachmentsStatus>('idle')
+  const attachmentsError = ref<string | null>(null)
+  let attachmentsLoadVersion = 0
 
   const artifactsList = ref<Artifact[]>([])
 
@@ -32,6 +45,89 @@ export const useArtifactsStore = defineStore('artifacts', () => {
 
   function resetCurrentArtifact() {
     currentArtifact.value = null
+    resetCurrentArtifactAttachments()
+  }
+
+  function resetCurrentArtifactAttachments() {
+    attachmentsLoadVersion += 1
+    attachmentsIndex.value = null
+    attachmentsDownloader.value = null
+    attachmentsStatus.value = 'idle'
+    attachmentsError.value = null
+  }
+
+  async function loadCurrentArtifactAttachments(artifact: Artifact) {
+    const loadVersion = ++attachmentsLoadVersion
+    attachmentsIndex.value = null
+    attachmentsDownloader.value = null
+    attachmentsStatus.value = 'loading'
+    attachmentsError.value = null
+
+    const fileIndex = artifact.file_index
+    const tarPath = FnnxService.findAttachmentsTarPath(fileIndex)
+    const indexPath = FnnxService.findAttachmentsIndexPath(fileIndex)
+
+    if (
+      (artifact.type !== ArtifactTypeEnum.model && artifact.type !== ArtifactTypeEnum.experiment) ||
+      !tarPath ||
+      !indexPath
+    ) {
+      if (loadVersion === attachmentsLoadVersion) attachmentsStatus.value = 'empty'
+      return
+    }
+
+    try {
+      const [indexOffset, indexSize] = fileIndex[indexPath]
+      const indexEnd = indexOffset + indexSize
+      const [tarOffset, tarSize] = fileIndex[tarPath]
+      const tarEnd = tarOffset + tarSize
+      if (
+        !Number.isSafeInteger(artifact.size) ||
+        artifact.size < 0 ||
+        !Number.isSafeInteger(indexOffset) ||
+        !Number.isSafeInteger(indexSize) ||
+        indexOffset < 0 ||
+        indexSize <= 0 ||
+        indexSize > MAX_ATTACHMENTS_INDEX_SIZE ||
+        !Number.isSafeInteger(indexEnd) ||
+        indexEnd > artifact.size ||
+        !Number.isSafeInteger(tarOffset) ||
+        !Number.isSafeInteger(tarSize) ||
+        tarOffset < 0 ||
+        tarSize < 0 ||
+        !Number.isSafeInteger(tarEnd) ||
+        tarEnd > artifact.size
+      ) {
+        throw new Error('Attachment index has an invalid range')
+      }
+
+      const url = await getDownloadUrl(artifact.id)
+      const downloader = new ModelDownloader(url)
+      const index = await downloader.getFileFromBucket<unknown>(fileIndex, indexPath)
+
+      if (!FnnxService.isValidAttachmentsIndex(index, tarSize)) {
+        throw new Error('Attachment index has invalid content')
+      }
+
+      if (loadVersion !== attachmentsLoadVersion || currentArtifact.value?.id !== artifact.id) {
+        return
+      }
+
+      if (!FnnxService.hasAttachments(index)) {
+        attachmentsStatus.value = 'empty'
+      } else {
+        attachmentsIndex.value = index
+        attachmentsDownloader.value = downloader
+        attachmentsStatus.value = 'available'
+      }
+    } catch (error) {
+      if (loadVersion !== attachmentsLoadVersion || currentArtifact.value?.id !== artifact.id) {
+        return
+      }
+
+      attachmentsError.value = getErrorMessage(error, 'Failed to check attachments')
+      attachmentsStatus.value = 'error'
+    }
   }
 
   async function refreshCurrentArtifact() {
@@ -221,6 +317,11 @@ export const useArtifactsStore = defineStore('artifacts', () => {
     currentArtifact,
     setCurrentArtifact,
     resetCurrentArtifact,
+    attachmentsIndex,
+    attachmentsDownloader,
+    attachmentsStatus,
+    attachmentsError,
+    loadCurrentArtifactAttachments,
     requestInfo,
     currentModelTag,
     currentModelMetadata,


### PR DESCRIPTION
Hide the Attachments tab only after a bounded, validated index read confirms there are no usable files. Reuse the parsed index in the attachment provider, retain a retry path on inspection errors, and ignore stale navigation results. Adds regression coverage for visibility, failures, malformed ranges, and navigation races.