### PR TITLE
fix/LM-191-redirect-invite-links

### DIFF
--- a/backend/luml/handlers/organizations.py
+++ b/backend/luml/handlers/organizations.py
@@ -219,7 +219,7 @@ class OrganizationHandler:
                 invite.email if invite else "",
                 get_invited_by_name(invite),
                 get_organization_email_name(invite),
-                config.APP_EMAIL_URL,
+                f"{config.APP_EMAIL_URL.rstrip('/')}/invitations",
             )
         except Exception as error:
             raise EmailDeliveryError(

--- a/backend/tests/unit/handlers/test_organization_invites.py
+++ b/backend/tests/unit/handlers/test_organization_invites.py
@@ -15,6 +15,7 @@ from luml.schemas.organization import (
     UserInvite,
 )
 from luml.schemas.user import CreateUser, UserOut
+from luml.settings import config
 
 handler = OrganizationHandler()
 
@@ -97,7 +98,12 @@ async def test_send_invite(
 
     assert result == mocked_invite
 
-    mock_send_organization_invite_email.assert_called_once()
+    mock_send_organization_invite_email.assert_called_once_with(
+        mocked_invite.email,
+        "",
+        "",
+        f"{config.APP_EMAIL_URL.rstrip('/')}/invitations",
+    )
     mock_create_organization_invite.assert_awaited_once()
 
 

--- a/frontend/src/components/authorization/AuthorizationWrapper.vue
+++ b/frontend/src/components/authorization/AuthorizationWrapper.vue
@@ -48,29 +48,39 @@ import MicrosoftIcon from '@/assets/img/authorization-services/microsoft.svg'
 import { useAuthStore } from '@/stores/auth'
 import { useUserStore } from '@/stores/user'
 import { onBeforeMount, ref } from 'vue'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
+import {
+  clearStoredAuthRedirect,
+  getStoredAuthRedirect,
+  storeAuthRedirect,
+} from '@/utils/authRedirect'
 
 const authStore = useAuthStore()
 const userStore = useUserStore()
 const router = useRouter()
+const route = useRoute()
 
 defineProps<TAuthorizationWrapperProps>()
 
 const servicesError = ref('')
+
+function startSsoLogin(provider: 'google' | 'microsoft') {
+  storeAuthRedirect(route.query.redirect)
+  window.location.href = `${import.meta.env.VITE_API_URL}/v1/auth/${provider}/login`
+}
 
 const services: IAuthorizationService[] = [
   {
     id: 'google',
     label: 'Sign in with Google',
     icon: GoogleIcon,
-    action: () => (window.location.href = `${import.meta.env.VITE_API_URL}/v1/auth/google/login`),
+    action: () => startSsoLogin('google'),
   },
   {
     id: 'microsoft',
     label: 'Sign in with Microsoft',
     icon: MicrosoftIcon,
-    action: () =>
-      (window.location.href = `${import.meta.env.VITE_API_URL}/v1/auth/microsoft/login`),
+    action: () => startSsoLogin('microsoft'),
   },
   // {
   //   id: 'github',
@@ -92,7 +102,9 @@ onBeforeMount(async () => {
       await authStore.loginWithMicrosoft(code)
     }
     await userStore.loadUser()
-    router.push({ name: 'home' })
+    const redirect = getStoredAuthRedirect()
+    clearStoredAuthRedirect()
+    router.push(redirect || { name: 'home' })
   } catch (e) {
     console.error(e)
   }

--- a/frontend/src/components/user/InvitationsList.vue
+++ b/frontend/src/components/user/InvitationsList.vue
@@ -1,0 +1,128 @@
+<template>
+  <div v-if="invitationsStore.invitations.length" class="table">
+    <div class="table-header">
+      <div class="table-row">
+        <div>Organization</div>
+        <div>Role</div>
+        <div>Invited by</div>
+        <div>Invitation sent on</div>
+        <div></div>
+      </div>
+    </div>
+    <div class="table-body">
+      <div
+        v-for="invitation in invitationsStore.invitations"
+        :key="invitation.id"
+        class="table-row"
+      >
+        <div class="cell">{{ invitation.organization.name }}</div>
+        <div class="cell">{{ invitation.role }}</div>
+        <div class="cell">{{ invitation.invited_by_user.full_name }}</div>
+        <div class="cell">{{ new Date(invitation.created_at).toLocaleDateString() }}</div>
+        <div class="buttons">
+          <d-button
+            severity="secondary"
+            variant="outlined"
+            :disabled="loading"
+            aria-label="Decline invitation"
+            @click="reject(invitation.id)"
+          >
+            <template #icon>
+              <Trash2 :size="12" />
+            </template>
+          </d-button>
+          <d-button
+            :disabled="loading"
+            aria-label="Accept invitation"
+            @click="accept(invitation.id, invitation.organization_id)"
+          >
+            <template #icon>
+              <Check :size="12" />
+            </template>
+          </d-button>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div v-else class="placeholder">There are currently no invitations awaiting response.</div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { Trash2, Check } from 'lucide-vue-next'
+import { useToast } from 'primevue'
+import { useInvitationsStore } from '@/stores/invitations'
+import { simpleErrorToast, simpleSuccessToast, simpleWardToast } from '@/lib/primevue/data/toasts'
+
+const invitationsStore = useInvitationsStore()
+const toast = useToast()
+const loading = ref(false)
+
+async function accept(inviteId: string, organizationId: string) {
+  loading.value = true
+
+  try {
+    await invitationsStore.acceptInvitation(inviteId, organizationId)
+    toast.add(simpleSuccessToast('You’ve joined the organization successfully.'))
+  } catch {
+    toast.add(simpleErrorToast('Failed to accept the invitation'))
+  } finally {
+    loading.value = false
+  }
+}
+
+async function reject(inviteId: string) {
+  loading.value = true
+
+  try {
+    await invitationsStore.rejectInvitation(inviteId)
+    toast.add(simpleWardToast('The invitation has been declined.'))
+  } catch {
+    toast.add(simpleErrorToast('Failed to reject the invitation'))
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.table {
+  background: var(--p-content-background);
+  border: 1px solid var(--p-content-border-color);
+  padding: 16px;
+  width: 100%;
+  border-radius: 8px;
+  overflow-x: auto;
+}
+.table-header {
+  font-weight: 500;
+  text-align: left;
+  border-bottom: 1px solid var(--p-divider-border-color);
+  padding: 10px 0;
+  margin-bottom: 12px;
+}
+.table-body {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+.table-row {
+  display: grid;
+  grid-template-columns: minmax(150px, 218px) 120px 190px 170px auto;
+  align-items: center;
+  gap: 24px;
+  min-width: 800px;
+}
+.buttons {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+.placeholder {
+  font-size: 20px;
+}
+.cell {
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+</style>

--- a/frontend/src/components/user/InvitationsList.vue
+++ b/frontend/src/components/user/InvitationsList.vue
@@ -1,5 +1,13 @@
 <template>
-  <div v-if="invitationsStore.invitations.length" class="table">
+  <div v-if="!invitationsStore.isLoaded || invitationsStore.isLoading" class="status">
+    <ProgressSpinner class="spinner" aria-label="Loading invitations" />
+    <span>Loading invitations...</span>
+  </div>
+  <div v-else-if="invitationsStore.loadError" class="status">
+    <span>Failed to load invitations.</span>
+    <d-button label="Retry" size="small" :loading="invitationsStore.isLoading" @click="retry" />
+  </div>
+  <div v-else-if="invitationsStore.invitations.length" class="table">
     <div class="table-header">
       <div class="table-row">
         <div>Organization</div>
@@ -50,13 +58,21 @@
 <script setup lang="ts">
 import { ref } from 'vue'
 import { Trash2, Check } from 'lucide-vue-next'
-import { useToast } from 'primevue'
+import { ProgressSpinner, useToast } from 'primevue'
 import { useInvitationsStore } from '@/stores/invitations'
 import { simpleErrorToast, simpleSuccessToast, simpleWardToast } from '@/lib/primevue/data/toasts'
 
 const invitationsStore = useInvitationsStore()
 const toast = useToast()
 const loading = ref(false)
+
+async function retry() {
+  try {
+    await invitationsStore.getInvitations()
+  } catch {
+    toast.add(simpleErrorToast('Failed to load invitations'))
+  }
+}
 
 async function accept(inviteId: string, organizationId: string) {
   loading.value = true
@@ -120,6 +136,16 @@ async function reject(inviteId: string) {
 }
 .placeholder {
   font-size: 20px;
+}
+.status {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  font-size: 18px;
+}
+.spinner {
+  width: 28px;
+  height: 28px;
 }
 .cell {
   overflow: hidden;

--- a/frontend/src/components/user/UserInvitations.vue
+++ b/frontend/src/components/user/UserInvitations.vue
@@ -19,92 +19,21 @@
         </div>
       </template>
       <h4 class="sub-title">Organization collaborators have access to specific orbits.</h4>
-      <div v-if="invitationsStore.invitations.length" class="table">
-        <div class="table-header">
-          <div class="table-row">
-            <div>Organization</div>
-            <div>Role</div>
-            <div>Invited by</div>
-            <div>Invitation sent on</div>
-            <div></div>
-          </div>
-        </div>
-        <div class="table-body">
-          <div
-            v-for="invitation in invitationsStore.invitations"
-            :key="invitation.id"
-            class="table-row"
-          >
-            <div class="cell">{{ invitation.organization.name }}</div>
-            <div class="cell">{{ invitation.role }}</div>
-            <div class="cell">{{ invitation.invited_by_user.full_name }}</div>
-            <div class="cell">{{ new Date(invitation.created_at).toLocaleDateString() }}</div>
-            <div class="buttons">
-              <d-button
-                severity="secondary"
-                variant="outlined"
-                :disabled="loading"
-                @click="reject(invitation.id)"
-              >
-                <template #icon>
-                  <Trash2 :size="12" />
-                </template>
-              </d-button>
-              <d-button
-                :disabled="loading"
-                @click="accept(invitation.id, invitation.organization_id)"
-              >
-                <template #icon>
-                  <Check :size="12" />
-                </template>
-              </d-button>
-            </div>
-          </div>
-        </div>
-      </div>
-      <div v-else class="placeholder">There are currently no invitations awaiting response.</div>
+      <InvitationsList />
     </Dialog>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref } from 'vue'
-import { Bell, Trash2, Check } from 'lucide-vue-next'
-import { Dialog, useToast } from 'primevue'
+import { Bell } from 'lucide-vue-next'
+import { Dialog } from 'primevue'
 import { useInvitationsStore } from '@/stores/invitations'
-import { simpleErrorToast, simpleSuccessToast, simpleWardToast } from '@/lib/primevue/data/toasts'
+import InvitationsList from './InvitationsList.vue'
 
 const invitationsStore = useInvitationsStore()
-const toast = useToast()
 
 const visible = ref(false)
-const loading = ref(false)
-
-async function accept(inviteId: string, organizationId: string) {
-  loading.value = true
-
-  try {
-    await invitationsStore.acceptInvitation(inviteId, organizationId)
-    toast.add(simpleSuccessToast('You’ve joined the organization successfully.'))
-  } catch {
-    toast.add(simpleErrorToast('Failed to accept the invitation'))
-  } finally {
-    loading.value = false
-  }
-}
-
-async function reject(inviteId: string) {
-  loading.value = true
-
-  try {
-    await invitationsStore.rejectInvitation(inviteId)
-    toast.add(simpleWardToast('The invitation has been declined.'))
-  } catch {
-    toast.add(simpleErrorToast('Failed to reject the invitation'))
-  } finally {
-    loading.value = false
-  }
-}
 </script>
 
 <style scoped>
@@ -130,44 +59,6 @@ async function reject(inviteId: string) {
   color: var(--p-text-muted-color);
   margin-bottom: 28px;
 }
-.table {
-  background: var(--p-content-background);
-  border: 1px solid var(--p-content-border-color);
-  padding: 16px;
-  width: 100%;
-  border-radius: 8px;
-}
-.table-header {
-  font-weight: 500;
-  text-align: left;
-  border-bottom: 1px solid var(--p-divider-border-color);
-  padding: 10px 0;
-  margin-bottom: 12px;
-}
-.table-body {
-  display: flex;
-  flex-direction: column;
-  gap: 12px;
-}
-.table-row {
-  display: grid;
-  grid-template-columns: 218px 120px 190px 170px auto;
-  align-items: center;
-  gap: 24px;
-}
-.buttons {
-  display: flex;
-  justify-content: flex-end;
-  gap: 8px;
-}
-.placeholder {
-  font-size: 20px;
-}
-.cell {
-  overflow: hidden;
-  text-overflow: ellipsis;
-}
-
 .bell-button :deep(svg) {
   color: var(--p-button-text-contrast-color);
 }

--- a/frontend/src/pages/EmailCheckPage.vue
+++ b/frontend/src/pages/EmailCheckPage.vue
@@ -6,13 +6,7 @@
     :hide-sso="true"
   >
     <template #form>
-      <d-button
-        type="submit"
-        label="Use another account"
-        rounded
-        fluid
-        @click="$router.push({ name: 'sign-up' })"
-      />
+      <d-button type="submit" label="Use another account" rounded fluid @click="goToSignUp" />
     </template>
     <!--<template #footer>
       <span>Did not receive it?</span>
@@ -25,4 +19,14 @@
 import AuthorizationWrapper from '@/components/authorization/AuthorizationWrapper.vue'
 
 import MainImage from '@/assets/img/form-bg.webp'
+import { getSafeAuthRedirect } from '@/utils/authRedirect'
+import { useRoute, useRouter } from 'vue-router'
+
+const route = useRoute()
+const router = useRouter()
+
+function goToSignUp() {
+  const redirect = getSafeAuthRedirect(route.query.redirect)
+  router.push({ name: 'sign-up', query: redirect ? { redirect } : {} })
+}
 </script>

--- a/frontend/src/pages/EmailConfirmedPage.vue
+++ b/frontend/src/pages/EmailConfirmedPage.vue
@@ -6,13 +6,7 @@
     :hide-sso="true"
   >
     <template #form>
-      <d-button
-        type="submit"
-        label="Go to account"
-        rounded
-        fluid
-        @click="$router.push({ name: 'sign-in' })"
-      />
+      <d-button type="submit" label="Go to account" rounded fluid @click="goToSignIn" />
     </template>
   </authorization-wrapper>
 </template>
@@ -21,4 +15,13 @@
 import AuthorizationWrapper from '@/components/authorization/AuthorizationWrapper.vue'
 
 import MainImage from '@/assets/img/form-bg.webp'
+import { getStoredAuthRedirect } from '@/utils/authRedirect'
+import { useRouter } from 'vue-router'
+
+const router = useRouter()
+
+function goToSignIn() {
+  const redirect = getStoredAuthRedirect()
+  router.push({ name: 'sign-in', query: redirect ? { redirect } : {} })
+}
 </script>

--- a/frontend/src/pages/InvitationsPage.vue
+++ b/frontend/src/pages/InvitationsPage.vue
@@ -1,0 +1,31 @@
+<template>
+  <section class="page">
+    <div>
+      <h1 class="title">Invitation center</h1>
+      <p class="subtitle">Organization invitations awaiting your response.</p>
+    </div>
+    <InvitationsList />
+  </section>
+</template>
+
+<script setup lang="ts">
+import InvitationsList from '@/components/user/InvitationsList.vue'
+</script>
+
+<style scoped>
+.page {
+  display: flex;
+  flex-direction: column;
+  gap: 28px;
+  padding: 40px 0;
+}
+.title {
+  font-size: 24px;
+  font-weight: 600;
+  text-transform: uppercase;
+}
+.subtitle {
+  color: var(--p-text-muted-color);
+  margin-top: 8px;
+}
+</style>

--- a/frontend/src/pages/SignInPage.vue
+++ b/frontend/src/pages/SignInPage.vue
@@ -71,7 +71,7 @@
     <template #footer>
       <div class="footer-message">
         <span>Don`t have an account? </span>
-        <router-link :to="{ name: 'sign-up' }" class="link">Sign up</router-link>
+        <router-link :to="signUpRoute" class="link">Sign up</router-link>
       </div>
       <router-link :to="{ name: 'forgot-password' }" class="link">Forgot password?</router-link>
     </template>
@@ -82,7 +82,7 @@
 import type { FormSubmitEvent } from '@primevue/forms'
 import type { IPostSignInRequest } from '@/lib/api/api.interfaces'
 
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 
 import AuthorizationWrapper from '@/components/authorization/AuthorizationWrapper.vue'
 import MainImage from '@/assets/img/form-bg.webp'
@@ -91,12 +91,14 @@ import { signInInitialValues } from '@/utils/forms/initialValues'
 import { signInResolver } from '@/utils/forms/resolvers'
 
 import { useAuthStore } from '@/stores/auth'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { useInputIcon } from '@/hooks/useInputIcon'
 import { getErrorMessage } from '@/helpers/helpers'
+import { clearStoredAuthRedirect, getSafeAuthRedirect } from '@/utils/authRedirect'
 
 const authStore = useAuthStore()
 const router = useRouter()
+const route = useRoute()
 
 const initialValues = ref(signInInitialValues)
 const resolver = ref(signInResolver)
@@ -104,6 +106,11 @@ const resolver = ref(signInResolver)
 const formRef = ref()
 const emailRef = ref<HTMLInputElement | null>(null)
 const formResponseError = ref('')
+const redirect = computed(() => getSafeAuthRedirect(route.query.redirect))
+const signUpRoute = computed(() => ({
+  name: 'sign-up',
+  query: redirect.value ? { redirect: redirect.value } : {},
+}))
 
 const { getCurrentInputIcon, onIconClick } = useInputIcon([emailRef], formRef, initialValues, false)
 
@@ -117,8 +124,8 @@ const onFormSubmit = async ({ valid, values }: FormSubmitEvent) => {
 
   try {
     await authStore.signIn(data)
-    const redirect = router.currentRoute.value.query.redirect as string
-    router.push(redirect || { name: 'home' })
+    clearStoredAuthRedirect()
+    router.push(redirect.value || { name: 'home' })
   } catch (e: unknown) {
     const errorDetails = getErrorMessage(e)
 

--- a/frontend/src/pages/SignUpPage.vue
+++ b/frontend/src/pages/SignUpPage.vue
@@ -96,7 +96,7 @@
     </template>
     <template #footer>
       <span>Already have an account? </span>
-      <router-link :to="{ name: 'sign-in' }" class="link">Sign in</router-link>
+      <router-link :to="signInRoute" class="link">Sign in</router-link>
     </template>
   </authorization-wrapper>
 </template>
@@ -105,19 +105,21 @@
 import AuthorizationWrapper from '@/components/authorization/AuthorizationWrapper.vue'
 import MainImage from '@/assets/img/form-bg.webp'
 
-import { ref, watch } from 'vue'
+import { computed, ref, watch } from 'vue'
 import type { FormSubmitEvent } from '@primevue/forms'
 
 import { useAuthStore } from '@/stores/auth'
 import type { IPostSignupRequest } from '@/lib/api/api.interfaces'
-import { useRouter } from 'vue-router'
+import { useRoute, useRouter } from 'vue-router'
 import { signUpInitialValues } from '@/utils/forms/initialValues'
 import { signUpResolver } from '@/utils/forms/resolvers'
 import { useInputIcon } from '@/hooks/useInputIcon'
 import { getErrorMessage } from '@/helpers/helpers'
+import { getSafeAuthRedirect, storeAuthRedirect } from '@/utils/authRedirect'
 
 const authStore = useAuthStore()
 const router = useRouter()
+const route = useRoute()
 
 const initialValues = ref(signUpInitialValues)
 
@@ -128,6 +130,11 @@ const usernameRef = ref<HTMLInputElement | null>(null)
 const emailRef = ref<HTMLInputElement | null>(null)
 
 const formResponseError = ref('')
+const redirect = computed(() => getSafeAuthRedirect(route.query.redirect))
+const signInRoute = computed(() => ({
+  name: 'sign-in',
+  query: redirect.value ? { redirect: redirect.value } : {},
+}))
 
 const { getCurrentInputIcon, onIconClick } = useInputIcon(
   [usernameRef, emailRef],
@@ -148,8 +155,11 @@ const onFormSubmit = async ({ valid, values }: FormSubmitEvent) => {
 
   try {
     await authStore.signUp(data)
-
-    router.push({ name: 'email-check' })
+    storeAuthRedirect(redirect.value)
+    router.push({
+      name: 'email-check',
+      query: redirect.value ? { redirect: redirect.value } : {},
+    })
   } catch (e: unknown) {
     const errorDetails = getErrorMessage(e)
 

--- a/frontend/src/router/index.ts
+++ b/frontend/src/router/index.ts
@@ -301,6 +301,15 @@ const router = createRouter({
       ],
     },
     {
+      path: '/invitations',
+      name: 'invitations',
+      component: () => import('../pages/InvitationsPage.vue'),
+      meta: {
+        requireAuth: true,
+        redirectToSignIn: true,
+      },
+    },
+    {
       path: '/:pathMatch(.*)*',
       name: '404',
       component: () => import('../pages/404Page.vue'),

--- a/frontend/src/router/middlewares/AuthMiddleware.test.ts
+++ b/frontend/src/router/middlewares/AuthMiddleware.test.ts
@@ -1,0 +1,53 @@
+import type { NavigationGuardNext, RouteLocationNormalized } from 'vue-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const authStore = {
+  isAuth: false,
+  checkIsLoggedIn: vi.fn(),
+}
+
+vi.mock('@/stores/auth', () => ({
+  useAuthStore: () => authStore,
+}))
+
+import { authMiddleware } from './AuthMiddleware'
+
+const from = {} as RouteLocationNormalized
+
+describe('authMiddleware invitation redirect', () => {
+  beforeEach(() => {
+    authStore.isAuth = false
+    authStore.checkIsLoggedIn.mockReset()
+  })
+
+  it('redirects unauthenticated invitation visitors to sign in', async () => {
+    const next = vi.fn() as NavigationGuardNext
+    const to = {
+      fullPath: '/invitations',
+      meta: { requireAuth: true, redirectToSignIn: true },
+    } as RouteLocationNormalized
+
+    await authMiddleware(to, from, next)
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(next).toHaveBeenCalledWith({
+      name: 'sign-in',
+      query: { redirect: '/invitations' },
+    })
+  })
+
+  it('allows authenticated invitation visitors through', async () => {
+    authStore.isAuth = true
+    const next = vi.fn() as NavigationGuardNext
+    const to = {
+      fullPath: '/invitations',
+      meta: { requireAuth: true, redirectToSignIn: true },
+    } as RouteLocationNormalized
+
+    await authMiddleware(to, from, next)
+
+    expect(next).toHaveBeenCalledOnce()
+    expect(next).toHaveBeenCalledWith()
+    expect(authStore.checkIsLoggedIn).not.toHaveBeenCalled()
+  })
+})

--- a/frontend/src/router/middlewares/AuthMiddleware.ts
+++ b/frontend/src/router/middlewares/AuthMiddleware.ts
@@ -19,7 +19,11 @@ export async function authMiddleware(
     }
   } catch {
     if (to.meta.requireAuth) {
-      next({ name: 'home' })
+      if (to.meta.redirectToSignIn) {
+        next({ name: 'sign-in', query: { redirect: to.fullPath } })
+      } else {
+        next({ name: 'home' })
+      }
     } else {
       next()
     }

--- a/frontend/src/router/router.type.ts
+++ b/frontend/src/router/router.type.ts
@@ -8,5 +8,6 @@ declare module 'vue-router' {
     mobileAvailable?: boolean
     showInvalidMessage?: number
     requireAuth?: boolean
+    redirectToSignIn?: boolean
   }
 }

--- a/frontend/src/stores/__tests__/invitations.test.ts
+++ b/frontend/src/stores/__tests__/invitations.test.ts
@@ -1,0 +1,97 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  getInvitations: vi.fn(),
+  acceptInvitation: vi.fn(),
+  rejectInvitation: vi.fn(),
+}))
+const organizationStore = vi.hoisted(() => ({
+  getAvailableOrganizations: vi.fn(),
+  setCurrentOrganizationId: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({ api: apiMocks }))
+vi.mock('@/stores/organization', () => ({ useOrganizationStore: () => organizationStore }))
+
+import { useInvitationsStore } from '../invitations'
+import type { Invitation } from '@/lib/api/api.interfaces'
+
+const invitation = {
+  id: 'invite-1',
+  organization_id: 'organization-1',
+} as Invitation
+
+describe('invitations store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+  })
+
+  it('tracks a successful invitation load', async () => {
+    apiMocks.getInvitations.mockResolvedValue([invitation])
+    const store = useInvitationsStore()
+
+    const request = store.getInvitations()
+    expect(store.isLoading).toBe(true)
+    expect(store.isLoaded).toBe(false)
+
+    await request
+
+    expect(store.invitations).toEqual([invitation])
+    expect(store.isLoading).toBe(false)
+    expect(store.isLoaded).toBe(true)
+    expect(store.loadError).toBe(false)
+  })
+
+  it('distinguishes a failed load from an empty result', async () => {
+    apiMocks.getInvitations.mockRejectedValue(new Error('unavailable'))
+    const store = useInvitationsStore()
+
+    await expect(store.getInvitations()).rejects.toThrow('unavailable')
+
+    expect(store.invitations).toEqual([])
+    expect(store.isLoading).toBe(false)
+    expect(store.isLoaded).toBe(true)
+    expect(store.loadError).toBe(true)
+  })
+
+  it('removes an accepted invitation after dependent data refreshes', async () => {
+    apiMocks.acceptInvitation.mockResolvedValue(undefined)
+    organizationStore.getAvailableOrganizations.mockResolvedValue(undefined)
+    const store = useInvitationsStore()
+    store.invitations = [invitation]
+
+    await store.acceptInvitation(invitation.id, invitation.organization_id)
+
+    expect(store.invitations).toEqual([])
+    expect(organizationStore.setCurrentOrganizationId).toHaveBeenCalledWith(
+      invitation.organization_id,
+    )
+  })
+
+  it('keeps an invitation when accepting it fails', async () => {
+    apiMocks.acceptInvitation.mockRejectedValue(new Error('unavailable'))
+    const store = useInvitationsStore()
+    store.invitations = [invitation]
+
+    await expect(store.acceptInvitation(invitation.id, invitation.organization_id)).rejects.toThrow(
+      'unavailable',
+    )
+
+    expect(store.invitations).toEqual([invitation])
+  })
+
+  it('removes a declined invitation only after success', async () => {
+    apiMocks.rejectInvitation.mockResolvedValueOnce(undefined).mockRejectedValueOnce(new Error())
+    const store = useInvitationsStore()
+    store.invitations = [invitation]
+
+    await store.rejectInvitation(invitation.id)
+    expect(store.invitations).toEqual([])
+
+    store.invitations = [invitation]
+    await expect(store.rejectInvitation(invitation.id)).rejects.toThrow()
+    expect(store.invitations).toEqual([invitation])
+  })
+})

--- a/frontend/src/stores/__tests__/user.test.ts
+++ b/frontend/src/stores/__tests__/user.test.ts
@@ -1,0 +1,63 @@
+import { createPinia, setActivePinia } from 'pinia'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiMocks = vi.hoisted(() => ({
+  getMe: vi.fn(),
+}))
+const invitationsStore = vi.hoisted(() => ({
+  getInvitations: vi.fn(),
+  reset: vi.fn(),
+}))
+const organizationStore = vi.hoisted(() => ({
+  getAvailableOrganizations: vi.fn(),
+  reset: vi.fn(),
+}))
+
+vi.mock('@/lib/api', () => ({ api: apiMocks }))
+vi.mock('@/stores/auth', () => ({ useAuthStore: () => ({ logout: vi.fn() }) }))
+vi.mock('@/stores/invitations', () => ({ useInvitationsStore: () => invitationsStore }))
+vi.mock('@/stores/organization', () => ({ useOrganizationStore: () => organizationStore }))
+
+import { useUserStore } from '../user'
+import type { IUser } from '../user.interfaces'
+
+const user = { id: 'user-1' } as IUser
+
+describe('user store', () => {
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    vi.clearAllMocks()
+    apiMocks.getMe.mockResolvedValue(user)
+    organizationStore.getAvailableOrganizations.mockResolvedValue(undefined)
+  })
+
+  it('loads invitations before organizations', async () => {
+    let resolveInvitations = () => {}
+    invitationsStore.getInvitations.mockReturnValue(
+      new Promise<void>((resolve) => {
+        resolveInvitations = resolve
+      }),
+    )
+    const store = useUserStore()
+
+    await store.loadUser()
+    await vi.waitFor(() => expect(invitationsStore.getInvitations).toHaveBeenCalledOnce())
+    expect(organizationStore.getAvailableOrganizations).not.toHaveBeenCalled()
+
+    resolveInvitations()
+    await vi.waitFor(() =>
+      expect(organizationStore.getAvailableOrganizations).toHaveBeenCalledOnce(),
+    )
+  })
+
+  it('loads organizations when invitations fail', async () => {
+    invitationsStore.getInvitations.mockRejectedValue(new Error('unavailable'))
+    const store = useUserStore()
+
+    await store.loadUser()
+
+    await vi.waitFor(() =>
+      expect(organizationStore.getAvailableOrganizations).toHaveBeenCalledOnce(),
+    )
+  })
+})

--- a/frontend/src/stores/invitations.ts
+++ b/frontend/src/stores/invitations.ts
@@ -8,9 +8,24 @@ export const useInvitationsStore = defineStore('invitations', () => {
   const organizationStore = useOrganizationStore()
 
   const invitations = ref<Invitation[]>([])
+  const isLoading = ref(false)
+  const isLoaded = ref(false)
+  const loadError = ref(false)
 
   async function getInvitations() {
-    invitations.value = await api.getInvitations()
+    isLoading.value = true
+    loadError.value = false
+
+    try {
+      invitations.value = await api.getInvitations()
+    } catch (error) {
+      invitations.value = []
+      loadError.value = true
+      throw error
+    } finally {
+      isLoading.value = false
+      isLoaded.value = true
+    }
   }
 
   async function acceptInvitation(inviteId: string, organizationId: string) {
@@ -35,10 +50,16 @@ export const useInvitationsStore = defineStore('invitations', () => {
 
   function reset() {
     invitations.value = []
+    isLoading.value = false
+    isLoaded.value = false
+    loadError.value = false
   }
 
   return {
     invitations,
+    isLoading,
+    isLoaded,
+    loadError,
     getInvitations,
     acceptInvitation,
     rejectInvitation,

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -71,8 +71,10 @@ export const useUserStore = defineStore('user', () => {
     () => user.value?.id,
     async (id) => {
       if (id) {
-        await invitationsStore.getInvitations()
-        await organizationStore.getAvailableOrganizations()
+        await Promise.allSettled([
+          invitationsStore.getInvitations(),
+          organizationStore.getAvailableOrganizations(),
+        ])
       } else {
         invitationsStore.reset()
         organizationStore.reset()

--- a/frontend/src/stores/user.ts
+++ b/frontend/src/stores/user.ts
@@ -71,10 +71,8 @@ export const useUserStore = defineStore('user', () => {
     () => user.value?.id,
     async (id) => {
       if (id) {
-        await Promise.allSettled([
-          invitationsStore.getInvitations(),
-          organizationStore.getAvailableOrganizations(),
-        ])
+        await invitationsStore.getInvitations().catch(() => undefined)
+        await organizationStore.getAvailableOrganizations()
       } else {
         invitationsStore.reset()
         organizationStore.reset()

--- a/frontend/src/utils/authRedirect.test.ts
+++ b/frontend/src/utils/authRedirect.test.ts
@@ -1,0 +1,39 @@
+import { beforeEach, describe, expect, it } from 'vitest'
+import {
+  clearStoredAuthRedirect,
+  getSafeAuthRedirect,
+  getStoredAuthRedirect,
+  storeAuthRedirect,
+} from './authRedirect'
+
+describe('auth redirect', () => {
+  beforeEach(() => localStorage.clear())
+
+  it('accepts same-origin application paths', () => {
+    expect(getSafeAuthRedirect('/invitations?tab=pending#invite')).toBe(
+      '/invitations?tab=pending#invite',
+    )
+  })
+
+  it.each(['https://example.com', '//example.com', 'invitations', null])(
+    'rejects unsafe redirect %s',
+    (redirect) => {
+      expect(getSafeAuthRedirect(redirect)).toBeUndefined()
+    },
+  )
+
+  it('stores and clears a safe redirect', () => {
+    storeAuthRedirect('/invitations')
+    expect(getStoredAuthRedirect()).toBe('/invitations')
+
+    clearStoredAuthRedirect()
+    expect(getStoredAuthRedirect()).toBeUndefined()
+  })
+
+  it('removes an existing redirect when a new value is unsafe', () => {
+    storeAuthRedirect('/invitations')
+    storeAuthRedirect('https://example.com')
+
+    expect(getStoredAuthRedirect()).toBeUndefined()
+  })
+})

--- a/frontend/src/utils/authRedirect.ts
+++ b/frontend/src/utils/authRedirect.ts
@@ -1,0 +1,30 @@
+const STORAGE_KEY = 'auth-redirect'
+
+export function getSafeAuthRedirect(value: unknown): string | undefined {
+  const candidate = Array.isArray(value) ? value[0] : value
+  if (typeof candidate !== 'string' || !candidate.startsWith('/') || candidate.startsWith('//')) {
+    return undefined
+  }
+
+  try {
+    const url = new URL(candidate, window.location.origin)
+    if (url.origin !== window.location.origin) return undefined
+    return `${url.pathname}${url.search}${url.hash}`
+  } catch {
+    return undefined
+  }
+}
+
+export function storeAuthRedirect(value: unknown) {
+  const redirect = getSafeAuthRedirect(value)
+  if (redirect) localStorage.setItem(STORAGE_KEY, redirect)
+  else localStorage.removeItem(STORAGE_KEY)
+}
+
+export function getStoredAuthRedirect() {
+  return getSafeAuthRedirect(localStorage.getItem(STORAGE_KEY))
+}
+
+export function clearStoredAuthRedirect() {
+  localStorage.removeItem(STORAGE_KEY)
+}

--- a/frontend/tests/integration/fixtures/data.ts
+++ b/frontend/tests/integration/fixtures/data.ts
@@ -130,6 +130,7 @@ export function makeInvitation(overrides: Record<string, unknown> = {}) {
       has_api_key: false,
     },
     created_at: '2025-02-01T00:00:00.000Z',
+    ...overrides,
   } as Record<string, unknown>
 }
 

--- a/frontend/tests/integration/invitations.spec.ts
+++ b/frontend/tests/integration/invitations.spec.ts
@@ -1,5 +1,20 @@
 import { test, expect } from './fixtures/test'
-import { USER_FIXTURE, makeInvitation, makeOrganization } from './fixtures/data'
+import type { ApiMocks } from './fixtures/api-mocks'
+import { INVITE_ID, USER_FIXTURE, makeInvitation, makeOrganization } from './fixtures/data'
+
+const SIGNIN_SUCCESS = {
+  detail: 'ok',
+  user_id: USER_FIXTURE.id,
+}
+
+async function mockAuthenticatedInvitationPage(apiMocks: ApiMocks) {
+  const organization = makeOrganization()
+  const invitation = makeInvitation({ organization })
+
+  await apiMocks.get('**/v1/auth/users/me', USER_FIXTURE)
+  await apiMocks.get('**/v1/users/me/organizations', [organization])
+  await apiMocks.get('**/v1/users/me/invitations', [invitation])
+}
 
 test.describe('Invitation links', () => {
   test('redirects unauthenticated users to sign in and preserves the invitation route', async ({
@@ -13,21 +28,187 @@ test.describe('Invitation links', () => {
 
     await page.goto('/invitations')
 
-    await expect(page).toHaveURL(/\/sign-in\?redirect=%2Finvitations$/)
+    await expect(page).toHaveURL(/\/sign-in\?redirect=\/invitations$/)
+  })
+
+  test('returns to invitations after password sign-in', async ({ page, apiMocks }) => {
+    let userRequests = 0
+    await apiMocks.get('**/v1/auth/users/me', () => {
+      userRequests += 1
+      return userRequests === 1
+        ? { status: 401, body: { detail: 'Not authenticated' } }
+        : USER_FIXTURE
+    })
+    await apiMocks.post('**/v1/auth/signin', SIGNIN_SUCCESS)
+    await apiMocks.get('**/v1/users/me/organizations', [makeOrganization()])
+    await apiMocks.get('**/v1/users/me/invitations', [])
+
+    await page.goto('/invitations')
+    await page.getByLabel('Email').fill('invitee@example.com')
+    await page.locator('#password input').fill('password123')
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click()
+
+    await expect(page).toHaveURL(/\/invitations$/)
+  })
+
+  test('returns to invitations after Google sign-in', async ({ page, apiMocks }) => {
+    let userRequests = 0
+    await apiMocks.get('**/v1/auth/users/me', () => {
+      userRequests += 1
+      return userRequests === 1
+        ? { status: 401, body: { detail: 'Not authenticated' } }
+        : USER_FIXTURE
+    })
+    await apiMocks.get('**/v1/auth/google/callback**', SIGNIN_SUCCESS)
+    await apiMocks.get('**/v1/users/me/organizations', [makeOrganization()])
+    await apiMocks.get('**/v1/users/me/invitations', [])
+
+    await page.goto('/invitations')
+    const appOrigin = new URL(page.url()).origin
+    await page.route('**/v1/auth/google/login', async (route) => {
+      await route.fulfill({
+        status: 302,
+        headers: { location: `${appOrigin}/sign-in?code=oauth-code&state=google` },
+      })
+    })
+    await page.getByRole('button', { name: 'Sign in with Google' }).click()
+
+    await expect(page).toHaveURL(/\/invitations$/)
+  })
+
+  test('preserves invitations through registration and email confirmation', async ({
+    page,
+    apiMocks,
+  }) => {
+    let userRequests = 0
+    await apiMocks.get('**/v1/auth/users/me', () => {
+      userRequests += 1
+      return userRequests === 1
+        ? { status: 401, body: { detail: 'Not authenticated' } }
+        : USER_FIXTURE
+    })
+    await apiMocks.post('**/v1/auth/signup', { detail: 'Please confirm your email address' })
+    await apiMocks.post('**/v1/auth/signin', SIGNIN_SUCCESS)
+    await apiMocks.get('**/v1/users/me/organizations', [makeOrganization()])
+    await apiMocks.get('**/v1/users/me/invitations', [])
+
+    await page.goto('/invitations')
+    await page.getByRole('link', { name: 'Sign up' }).click()
+    await expect(page).toHaveURL(/\/sign-up\?redirect=\/invitations$/)
+
+    await page.getByLabel('Email').fill('invitee@example.com')
+    await page.locator('#password input').fill('password123')
+    await page.getByRole('button', { name: 'Sign up', exact: true }).click()
+    await expect(page).toHaveURL(/\/email-check\?redirect=\/invitations$/)
+
+    await page.goto('/email-confirmed')
+    await page.getByRole('button', { name: 'Go to account' }).click()
+    await expect(page).toHaveURL(/\/sign-in\?redirect=\/invitations$/)
+
+    await page.getByLabel('Email').fill('invitee@example.com')
+    await page.locator('#password input').fill('password123')
+    await page.getByRole('button', { name: 'Sign in', exact: true }).click()
+    await expect(page).toHaveURL(/\/invitations$/)
   })
 
   test('shows the invitation page to authenticated users', async ({ page, apiMocks }) => {
-    const organization = makeOrganization()
-    const invitation = makeInvitation({ organization })
-
-    await apiMocks.get('**/v1/auth/users/me', USER_FIXTURE)
-    await apiMocks.get('**/v1/users/me/organizations', [organization])
-    await apiMocks.get('**/v1/users/me/invitations', [invitation])
+    await mockAuthenticatedInvitationPage(apiMocks)
 
     await page.goto('/invitations')
 
     await expect(page).toHaveURL(/\/invitations$/)
     await expect(page.getByRole('heading', { name: 'Invitation center' })).toBeVisible()
+    await expect(page.getByText('Acme Corp')).toBeVisible()
+  })
+
+  test('shows loading while invitations are being fetched', async ({ page, apiMocks }) => {
+    let resolveInvitations: (value: unknown[]) => void = () => {}
+    const invitations = new Promise<unknown[]>((resolve) => {
+      resolveInvitations = resolve
+    })
+
+    await apiMocks.get('**/v1/auth/users/me', USER_FIXTURE)
+    await apiMocks.get('**/v1/users/me/organizations', [makeOrganization()])
+    await apiMocks.get('**/v1/users/me/invitations', () => invitations)
+
+    await page.goto('/invitations')
+    await expect(page.getByText('Loading invitations...')).toBeVisible()
+
+    resolveInvitations([])
+    await expect(
+      page.getByText('There are currently no invitations awaiting response.'),
+    ).toBeVisible()
+  })
+
+  test('shows an error and retries loading invitations', async ({ page, apiMocks }) => {
+    let invitationRequests = 0
+    await apiMocks.get('**/v1/auth/users/me', USER_FIXTURE)
+    await apiMocks.get('**/v1/users/me/organizations', [makeOrganization()])
+    await apiMocks.get('**/v1/users/me/invitations', () => {
+      invitationRequests += 1
+      return invitationRequests === 1
+        ? { status: 500, body: { detail: 'Unavailable' } }
+        : [makeInvitation({ organization: makeOrganization() })]
+    })
+
+    await page.goto('/invitations')
+    await expect(page.getByText('Failed to load invitations.')).toBeVisible()
+    await page.getByRole('button', { name: 'Retry' }).click()
+
+    await expect(page.getByText('Acme Corp')).toBeVisible()
+  })
+
+  test('accepts an invitation and shows success', async ({ page, apiMocks }) => {
+    await mockAuthenticatedInvitationPage(apiMocks)
+    await apiMocks.post(`**/v1/users/me/invitations/${INVITE_ID}/accept`, {})
+
+    await page.goto('/invitations')
+    await page.getByRole('button', { name: 'Accept invitation' }).click()
+
+    await expect(page.getByText('You’ve joined the organization successfully.')).toBeVisible()
+    await expect(
+      page.getByText('There are currently no invitations awaiting response.'),
+    ).toBeVisible()
+  })
+
+  test('keeps an invitation when accepting fails', async ({ page, apiMocks }) => {
+    await mockAuthenticatedInvitationPage(apiMocks)
+    await apiMocks.post(`**/v1/users/me/invitations/${INVITE_ID}/accept`, {
+      status: 500,
+      body: { detail: 'Unavailable' },
+    })
+
+    await page.goto('/invitations')
+    await page.getByRole('button', { name: 'Accept invitation' }).click()
+
+    await expect(page.getByText('Failed to accept the invitation')).toBeVisible()
+    await expect(page.getByText('Acme Corp')).toBeVisible()
+  })
+
+  test('declines an invitation and shows success', async ({ page, apiMocks }) => {
+    await mockAuthenticatedInvitationPage(apiMocks)
+    await apiMocks.post(`**/v1/users/me/invitations/${INVITE_ID}/reject`, {})
+
+    await page.goto('/invitations')
+    await page.getByRole('button', { name: 'Decline invitation' }).click()
+
+    await expect(page.getByText('The invitation has been declined.')).toBeVisible()
+    await expect(
+      page.getByText('There are currently no invitations awaiting response.'),
+    ).toBeVisible()
+  })
+
+  test('keeps an invitation when declining fails', async ({ page, apiMocks }) => {
+    await mockAuthenticatedInvitationPage(apiMocks)
+    await apiMocks.post(`**/v1/users/me/invitations/${INVITE_ID}/reject`, {
+      status: 500,
+      body: { detail: 'Unavailable' },
+    })
+
+    await page.goto('/invitations')
+    await page.getByRole('button', { name: 'Decline invitation' }).click()
+
+    await expect(page.getByText('Failed to reject the invitation')).toBeVisible()
     await expect(page.getByText('Acme Corp')).toBeVisible()
   })
 })

--- a/frontend/tests/integration/invitations.spec.ts
+++ b/frontend/tests/integration/invitations.spec.ts
@@ -119,7 +119,7 @@ test.describe('Invitation links', () => {
 
     await expect(page).toHaveURL(/\/invitations$/)
     await expect(page.getByRole('heading', { name: 'Invitation center' })).toBeVisible()
-    await expect(page.getByText('Acme Corp')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Acme Corp')).toBeVisible()
   })
 
   test('shows loading while invitations are being fetched', async ({ page, apiMocks }) => {
@@ -156,7 +156,7 @@ test.describe('Invitation links', () => {
     await expect(page.getByText('Failed to load invitations.')).toBeVisible()
     await page.getByRole('button', { name: 'Retry' }).click()
 
-    await expect(page.getByText('Acme Corp')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Acme Corp')).toBeVisible()
   })
 
   test('accepts an invitation and shows success', async ({ page, apiMocks }) => {
@@ -183,7 +183,7 @@ test.describe('Invitation links', () => {
     await page.getByRole('button', { name: 'Accept invitation' }).click()
 
     await expect(page.getByText('Failed to accept the invitation')).toBeVisible()
-    await expect(page.getByText('Acme Corp')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Acme Corp')).toBeVisible()
   })
 
   test('declines an invitation and shows success', async ({ page, apiMocks }) => {
@@ -210,6 +210,6 @@ test.describe('Invitation links', () => {
     await page.getByRole('button', { name: 'Decline invitation' }).click()
 
     await expect(page.getByText('Failed to reject the invitation')).toBeVisible()
-    await expect(page.getByText('Acme Corp')).toBeVisible()
+    await expect(page.getByRole('main').getByText('Acme Corp')).toBeVisible()
   })
 })

--- a/frontend/tests/integration/invitations.spec.ts
+++ b/frontend/tests/integration/invitations.spec.ts
@@ -1,0 +1,33 @@
+import { test, expect } from './fixtures/test'
+import { USER_FIXTURE, makeInvitation, makeOrganization } from './fixtures/data'
+
+test.describe('Invitation links', () => {
+  test('redirects unauthenticated users to sign in and preserves the invitation route', async ({
+    page,
+    apiMocks,
+  }) => {
+    await apiMocks.get('**/v1/auth/users/me', {
+      status: 401,
+      body: { detail: 'Not authenticated' },
+    })
+
+    await page.goto('/invitations')
+
+    await expect(page).toHaveURL(/\/sign-in\?redirect=%2Finvitations$/)
+  })
+
+  test('shows the invitation page to authenticated users', async ({ page, apiMocks }) => {
+    const organization = makeOrganization()
+    const invitation = makeInvitation({ organization })
+
+    await apiMocks.get('**/v1/auth/users/me', USER_FIXTURE)
+    await apiMocks.get('**/v1/users/me/organizations', [organization])
+    await apiMocks.get('**/v1/users/me/invitations', [invitation])
+
+    await page.goto('/invitations')
+
+    await expect(page).toHaveURL(/\/invitations$/)
+    await expect(page.getByRole('heading', { name: 'Invitation center' })).toBeVisible()
+    await expect(page.getByText('Acme Corp')).toBeVisible()
+  })
+})

--- a/frontend/tests/integration/invitations.spec.ts
+++ b/frontend/tests/integration/invitations.spec.ts
@@ -96,6 +96,7 @@ test.describe('Invitation links', () => {
     await page.getByRole('link', { name: 'Sign up' }).click()
     await expect(page).toHaveURL(/\/sign-up\?redirect=\/invitations$/)
 
+    await page.getByLabel('Name').fill('Invitee')
     await page.getByLabel('Email').fill('invitee@example.com')
     await page.locator('#password input').fill('password123')
     await page.getByRole('button', { name: 'Sign up', exact: true }).click()


### PR DESCRIPTION
Invitation emails now link to a dedicated invitation center. Protected navigation preserves a validated invitation destination through password, SSO, and registration flows, while the invitation view reports loading and retryable failures. Tests cover routing and invitation actions.